### PR TITLE
Spring Boot Setup command should be UI friendly

### DIFF
--- a/src/main/java/org/jboss/forge/addon/springboot/ui/SpringBootSetupCommand.java
+++ b/src/main/java/org/jboss/forge/addon/springboot/ui/SpringBootSetupCommand.java
@@ -48,7 +48,7 @@ public class SpringBootSetupCommand extends AbstractProjectCommand {
 
     @Override
     public UICommandMetadata getMetadata(UIContext context) {
-        return Metadata.forCommand(SpringBootSetupCommand.class).name("spring-boot-setup").category(Categories.create("Spring Boot"));
+        return Metadata.forCommand(SpringBootSetupCommand.class).name("Spring Boot: Setup").category(Categories.create("Spring Boot"));
     }
 
     @Override


### PR DESCRIPTION
The name will be converted to a shell-friendly name (spring-boot-setup) automatically